### PR TITLE
Add Caddy as reverse proxy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,10 +4,9 @@
     }
 }
 
-nexus.docker.localhost:80 {
+:80 {
     reverse_proxy http://nexus:8081 {
         @error status 401
         replace_status @error 403
-
     }
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,13 @@
+{
+    log {
+        level  DEBUG
+    }
+}
+
+nexus.docker.localhost:80 {
+    reverse_proxy http://nexus:8081 {
+        @error status 401
+        replace_status @error 403
+
+    }
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,3 @@
-{
-    log {
-        level  DEBUG
-    }
-}
-
 :80 {
     reverse_proxy http://nexus:8081 {
         @error status 401

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ For example
 
 ```
 [global]
-index = http://localhost:8081/repository/pypi-proxy/pypi
-index-url = http://localhost:8081/repository/pypi-proxy/simple
+index = http://localhost:8080/repository/pypi-proxy/pypi
+index-url = http://localhost:8080/repository/pypi-proxy/simple
 ```
 
 You should now only be able to install packages from the allowlist.
@@ -78,7 +78,7 @@ For example
 ```
 local({
     r <- getOption("repos")
-    r["CRAN"] <- "http://localhost:8081/repository/cran-proxy"
+    r["CRAN"] <- "http://localhost:8080/repository/cran-proxy"
     options(repos=r)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The container [command](entrypoint.sh)
   1. Runs initial configuration (creates a role, repositories, content selectors, _etc._)
 1. Reruns the content selector configuration (which enforces the allowlists) every time either of the allowlist files are modified
 
+[Caddy](https://caddyserver.com/) acts as a reverse proxy, passing requests to the Nexus OSS server.
+The [configuration file](Caddyfile) replaces [401](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) responses from Nexus OSS with [403](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) so that pip does not prompt a user for authentication when attempting to install a blacked package.
+
 ### Usage
 
 #### Pip

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,6 @@ services:
   nexus:
     container_name: nexus
     image: sonatype/nexus3:3.54.1
-    ports:
-      - "8081:8081"
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
@@ -24,3 +22,10 @@ services:
       - ./allowlists:/allowlists
       - ./nexus-data:/nexus-data
     restart: always
+  reverse-proxy:
+    container_name: reverse-proxy
+    image: caddy:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,6 @@ services:
     container_name: reverse-proxy
     image: caddy:2.6-alpine
     ports:
-      - "80:80"
+      - "8080:80"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
     restart: always
   reverse-proxy:
     container_name: reverse-proxy
-    image: caddy:latest
+    image: caddy:2.6-alpine
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
Add Caddy acting as a reverse proxy for Nexus.

Caddy will replace 401 status responses from Nexus with 403, which prevents pip from asking for authentication when trying to install blocked packages.