### PR TITLE
Add authentication check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN apk add --no-cache curl entr
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 CMD ["./entrypoint.sh"]
+
+HEALTHCHECK CMD python3 configure_nexus.py --admin-password ${NEXUS_ADMIN_PASSWORD} --nexus-host ${NEXUS_HOST} --nexus-port ${NEXUS_PORT} test-authentication

--- a/configure_nexus.py
+++ b/configure_nexus.py
@@ -402,8 +402,8 @@ def main():
     parser.add_argument(
         "--nexus-host",
         type=str,
-        default="http://localhost",
-        help="Hostname of the Nexus server (default http://localhost)"
+        default="localhost",
+        help="Hostname of the Nexus server (default localhost)"
     )
     parser.add_argument(
         "--nexus-port",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,5 +35,11 @@ else
     echo "$(timestamp) No initial password file found, skipping initial configuration"
 fi
 
+# Test authentication
+if ! python3 configure_nexus.py --admin-password "$NEXUS_ADMIN_PASSWORD" --nexus-host "$NEXUS_HOST" --nexus-port "$NEXUS_PORT" test-authentication; then
+    echo "$(timestamp) API authentication test failed, exiting"
+    exit 1
+fi
+
 # Run allowlist configuration whenever allowlist files are modified
 find "$ALLOWLIST_DIR"/*.allowlist | entr -np python3 configure_nexus.py --admin-password "$NEXUS_ADMIN_PASSWORD" --nexus-host "$NEXUS_HOST" --nexus-port "$NEXUS_PORT" update-allowlists --packages "$NEXUS_PACKAGES" --pypi-package-file "$PYPI_ALLOWLIST" --cran-package-file "$CRAN_ALLOWLIST"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ until curl -s "$NEXUS_HOST":"$NEXUS_PORT" > /dev/null; do
     echo "$(timestamp) Waiting for Nexus"
     sleep 10
 done
-echo "$(timestamp) Connected to Nexus"
+echo "$(timestamp) Nexus is running"
 
 # Initial configuration
 if [ -f "$NEXUS_DATA_DIR/admin.password" ]; then


### PR DESCRIPTION
Closes #4 

Adds

- A command to test authentication (using the users API route)
- A check that authentication works in the entrypoint (which will return a non-zero exit code upon failure)
- A healthcheck for authentication

We should think a bit about what works best for us and others.
@jemrobinson Can you see healthchecks for Azure container instance or set up alerts? The same question for if a container process returns a non-zero exit code.