### PR TITLE
Change how allowlist updating is handled

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,11 +6,11 @@ on:
     branches: ["main"]
 
 jobs:
-  lint:
-    name: Lint
+  lint_python:
+    name: Lint Python
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      - name: Check out the repository
         uses: actions/checkout@v3
 
       - name: Set up Python
@@ -23,3 +23,13 @@ jobs:
 
       - name: Lint
         run: hatch run lint:all
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,5 +41,5 @@ if ! nexus-allowlist --admin-password "$NEXUS_ADMIN_PASSWORD" --nexus-host "$NEX
     exit 1
 fi
 
-# Run allowlist configuration whenever allowlist files are modified
-find "$ALLOWLIST_DIR"/*.allowlist | entr -np nexus-allowlist --admin-password "$NEXUS_ADMIN_PASSWORD" --nexus-host "$NEXUS_HOST" --nexus-port "$NEXUS_PORT" update-allowlists --packages "$NEXUS_PACKAGES" --pypi-package-file "$PYPI_ALLOWLIST" --cran-package-file "$CRAN_ALLOWLIST"
+# Run allowlist configuration now, and again whenever allowlist files are modified
+find "$ALLOWLIST_DIR"/*.allowlist | entr -n nexus-allowlist --admin-password "$NEXUS_ADMIN_PASSWORD" --nexus-host "$NEXUS_HOST" --nexus-port "$NEXUS_PORT" update-allowlists --packages "$NEXUS_PACKAGES" --pypi-package-file "$PYPI_ALLOWLIST" --cran-package-file "$CRAN_ALLOWLIST"


### PR DESCRIPTION
- Remove allowlist enforcement (content selectors, privileges) from initial configuration routine.
- (Container) Always run the update allowlist command once, and again whenever the allowlist files are updated.
- Add shellcheck job for lint workflow

Closes #16 