### PR TITLE
Add archive.rds and expand package path to allow archived versions of R packages

### DIFF
--- a/nexus_allowlist/actions.py
+++ b/nexus_allowlist/actions.py
@@ -228,7 +228,11 @@ def recreate_privileges(
                 nexus_api,
                 name=f"cran-{package}",
                 description=f"allow access to {package} on CRAN",
-                expression=f'format == "r" and (path=^"/src/contrib/{package}_" or path=^"/src/contrib/Archive/{package}/{package}_")',
+                expression=(
+                    'format == "r" '
+                    f'and (path=^"/src/contrib/{package}_" '
+                    f'or path=^"/src/contrib/Archive/{package}/{package}_")'
+                ),
                 repo_type=_NEXUS_REPOSITORIES["cran_proxy"].repo_type,
                 repo=_NEXUS_REPOSITORIES["cran_proxy"].name,
             )

--- a/nexus_allowlist/actions.py
+++ b/nexus_allowlist/actions.py
@@ -173,6 +173,18 @@ def recreate_privileges(
     )
     cran_privilege_names.append(privilege_name)
 
+    # Content selector and privilege for CRAN 'archive.rds' file which contains an
+    # metadata for all archived packages
+    privilege_name = create_content_selector_and_privilege(
+        nexus_api,
+        name="archive",
+        description="Allow access to 'archive.rds' file in CRAN repository",
+        expression='format == "r" and path=="/src/contrib/Meta/archive.rds"',
+        repo_type=_NEXUS_REPOSITORIES["cran_proxy"].repo_type,
+        repo=_NEXUS_REPOSITORIES["cran_proxy"].name,
+    )
+    cran_privilege_names.append(privilege_name)
+
     # Create content selectors and privileges for packages according to the
     # package setting
     if packages == "all":
@@ -216,7 +228,7 @@ def recreate_privileges(
                 nexus_api,
                 name=f"cran-{package}",
                 description=f"allow access to {package} on CRAN",
-                expression=f'format == "r" and path=^"/src/contrib/{package}_"',
+                expression=f'format == "r" and (path=^"/src/contrib/{package}_" or path=^"/src/contrib/Archive/{package}/{package}_")',
                 repo_type=_NEXUS_REPOSITORIES["cran_proxy"].repo_type,
                 repo=_NEXUS_REPOSITORIES["cran_proxy"].name,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ all = [
 [tool.black]
 target-version = ["py310", "py311"]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
   "A",
   "ARG",
@@ -91,12 +91,12 @@ unfixable = [
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["nexus_allowlist"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]


### PR DESCRIPTION
This allows the R `remotes` package to download and install older versions of R packages. It permits required metadata to be downloaded and modifies the content selector for each package to allow archived package versions to be found.

Closes #57 