### PR TITLE
Add quotes in Dockerfile cmd line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN pip3 install --no-cache-dir .
 
 CMD ["./entrypoint.sh"]
 
-HEALTHCHECK CMD nexus-allowlist --admin-password ${NEXUS_ADMIN_PASSWORD} --nexus-host ${NEXUS_HOST} --nexus-port ${NEXUS_PORT} test-authentication
+HEALTHCHECK CMD nexus-allowlist --admin-password "${NEXUS_ADMIN_PASSWORD}" --nexus-host "${NEXUS_HOST}" --nexus-port "${NEXUS_PORT}" test-authentication


### PR DESCRIPTION
Adds quotes around environment variables in the Dockerfile to prevent special characters from causing the healthcheck to faile

Closes #77 