### PR TITLE
Accept EULA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN pip3 install --no-cache-dir .
 
 CMD ["./entrypoint.sh"]
 
-HEALTHCHECK CMD nexus-allowlist --admin-password ${NEXUS_ADMIN_PASSWORD} --nexus-host ${NEXUS_HOST} --nexus-port ${NEXUS_PORT} test-authentication
+HEALTHCHECK CMD nexus-allowlist --admin-password "${NEXUS_ADMIN_PASSWORD}" --nexus-host "${NEXUS_HOST}" --nexus-port "${NEXUS_PORT}" test-authentication

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   nexus:
     container_name: nexus
-    image: sonatype/nexus3:3.71.0
+    image: sonatype/nexus3:3.77.2
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro

--- a/nexus_allowlist/cli.py
+++ b/nexus_allowlist/cli.py
@@ -174,6 +174,7 @@ def initial_configuration(args: argparse.Namespace) -> None:
         - Creating a role
         - Giving anonymous users ONLY the previously defined role
         - Enabling anonymous access
+        - Accepting the EULA for Sonatype Nexus Repository Community Edition
 
     This does not configure the allowlists.
 
@@ -207,6 +208,9 @@ def initial_configuration(args: argparse.Namespace) -> None:
 
     # Enable anonymous access
     nexus_api.enable_anonymous_access()
+
+    # Accept the EULA
+    nexus_api.accept_eula()
 
 
 def update_allow_lists(args: argparse.Namespace) -> None:


### PR DESCRIPTION
Sonatype Nexus versions >= `3.77.0` require acceptance of a EULA before they can be used. This PR accepts the EULA via the REST API.

Tested locally using `docker compose`